### PR TITLE
fix the badge to use numbers instead of booleans

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ export default function App() {
     const URLParams = new URLSearchParams(window.location.search);
     const delaySearch = URLParams.get('a') || 0;
     const delayDetails = URLParams.get('b') || 0;
-    const showBadge = URLParams.get('c') || false;
+    const showBadge = URLParams.get('c') || 0;
 
     setDelaySearch(delaySearch);
     setDelayDetails(delayDetails);
@@ -40,7 +40,7 @@ export default function App() {
 
   return (
     <div className="App">
-      {showBadge && <Badge />}
+      {showBadge === '1' && <Badge />}
       <header className="App-header">
         <div className="App-searchbar">
           <Logo />


### PR DESCRIPTION
At one point I made the mistake of making `c` read `true` or `false` instead of reading `0` or `1`. This is fixed on App.jsx.